### PR TITLE
Feat: ABCheckboardView 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ https://github.com/January1st-98/AnimationBackground-Swift.git
 ```
 
 ## Usage
-As of 2022-02-15, two features are available.
+As of 2022-02-19, two features are available.
 1. `ABRainingView`: A screen that shows the user's registered image falling from the top of the view to the bottom, as if it's raining. You can register multiple images. The image moves faster and faster.
 2. `ABRisingView`: This view shows the images registered by the user from the bottom to the top. You can register multiple images. The image moves faster and faster.
+3. `ABCheckboardView`: This view shows one image registered by a user in a chessboard format. The image zooms out and in at small intervals.
 
-|**`ABRainingView`**|**`ABRisingView`**|
-|:-----------------:|:----------------:|
-|![ABRainingView Example](https://user-images.githubusercontent.com/76734067/219017953-0ac70ea0-5a0a-40b5-b841-b6d32dee2d0f.gif)|![ABRisingView Exaple](https://user-images.githubusercontent.com/76734067/219018256-ebea6126-68e9-4c6d-b9a9-9a02b3bec2fa.gif)|
+|**`ABRainingView`**|**`ABRisingView`**|**`ABCheckboardView`**|
+|:-----------------:|:----------------:|:--------------------:|
+|![ABRainingView Example](https://user-images.githubusercontent.com/76734067/219017953-0ac70ea0-5a0a-40b5-b841-b6d32dee2d0f.gif)|![ABRisingView Exaple](https://user-images.githubusercontent.com/76734067/219018256-ebea6126-68e9-4c6d-b9a9-9a02b3bec2fa.gif)|![ABCheckboardView Example](https://user-images.githubusercontent.com/76734067/219884466-b4154285-3820-4e2b-acae-1332d95034d9.gif)|
 
 
 ### ABRainingView, ABRisingView
@@ -26,15 +27,15 @@ The following steps are required to use `ABRainingView` and `ABRisingView`.
     let rainingView = ABRainingView(opacity: 0.5)
     let risingView = ABRisingView(opacity: 1.0)
     ```
-2. Use the `configureImages(images:)` method to register the images to be used in the effect.<br>
+2. Use the `configureImages(images:)` method to register the images to be used in the view<br>
     ```swift
     rainView.configureImages(
-            images: [
-                UIImage(named: "swift-logo")!,
-                UIImage(named: "python-logo")!,
-                UIImage(named: "ruby-logo")!
-            ]
-        )
+        images: [
+            UIImage(named: "swift-logo")!,
+            UIImage(named: "python-logo")!,
+            UIImage(named: "ruby-logo")!
+        ]
+    )
     ```
 3. Activate the animation through the `activate` method.<br>
     **It's important to note that this needs to be done in `viewDidLayoutSubviews` because we need the size information of the views to run the animation and calculate the size of the image.**
@@ -44,7 +45,26 @@ The following steps are required to use `ABRainingView` and `ABRisingView`.
     }
     ```
 
+### ABCheckboardView
+The following steps are required to use `ABCheckboardView`.
 
+1. Create class instance<br>
+    You can simply create an instance of ABCheckboardView.
+    ```swift
+    let checkView = ABCheckboardView()
+    ```
+2. Use the `configureImages(images:)` method to register the images to be used in the view. Unlike `ABRainingView` and `ABRisingView`, only one image can be registered.<br>
+    ```swift
+    checkView.configureImage(image: UIImage(named: "swift-logo")!)
+    ```
+3. Run the activate method to place the registered image in the view and animate it.<br>
+    **It's important to note that this needs to be done in `viewDidLayoutSubviews` because we need the size information of the views to run the animation and calculate the size of the image.**
+    ```swift
+    override func viewDidLayoutSubviews() {
+        checkView.activate()
+    }
+    ```
+    
 ## Author
 - [Jaehoon So](https://github.com/January1st-98)
 - E-mail: jhspacelover@naver.com

--- a/Sources/AnimationBackground/ABCheckboardView.swift
+++ b/Sources/AnimationBackground/ABCheckboardView.swift
@@ -29,6 +29,7 @@ public final class ABCheckBoardView: UIView {
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
+        self.clipsToBounds = true
         
     }
     

--- a/Sources/AnimationBackground/ABCheckboardView.swift
+++ b/Sources/AnimationBackground/ABCheckboardView.swift
@@ -1,0 +1,127 @@
+//
+//  ABCheckBoardView.swift
+//  AnimationBackground-Swift
+//
+//  Created by Jaehoon So on 2023/02/19.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+public final class ABCheckBoardView: UIView {
+
+    enum Metric: Int {
+        case minimumDivideValue = 8
+        case maximumDivideValue = 6
+    }
+    
+    private var imageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(systemName: "photo"))
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return imageView
+    }()
+    
+    private var mainImage: UIImage = UIImage(systemName: "photo")!
+    private var coordinates: [[(x: CGFloat, y: CGFloat)]] = []
+    private var imageViews: [UIImageView] = []
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+    }
+    
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+@available(iOS 13.0, *)
+extension ABCheckBoardView {
+        
+    public func configureImage(image: UIImage) {
+        self.mainImage = image
+    }
+    
+    public func activate() {
+        print(#function)
+        let width = self.bounds.width
+        let height = self.bounds.height
+        let maximumSize = width / CGFloat(Metric.maximumDivideValue.rawValue)
+        let minimumSize = width / CGFloat(Metric.minimumDivideValue.rawValue)
+        
+        
+        createCoordinates(width: width, height: height)
+        addImageViews(width: width, height: height)
+        
+        let dividedTime = 1 / Double(self.coordinates.count)
+        
+        for (index, imageView) in imageViews.enumerated() {
+            UIView.animate(
+                withDuration: 1,
+                delay: dividedTime * Double(index),
+                options: [.repeat, .autoreverse]) {
+                    imageView.bounds.size.width += (maximumSize - minimumSize)
+                    imageView.bounds.size.height += (maximumSize - minimumSize)
+                }
+        }
+        
+    }
+    
+    public func createCoordinates(width: CGFloat, height: CGFloat) {
+        print(#function)
+        let viewSize = width / CGFloat(Metric.maximumDivideValue.rawValue)
+        let numberOfHeightBlock = Int(height / viewSize + 1)
+        
+        createCoordinatesArray(count: numberOfHeightBlock)
+        
+        (0..<self.coordinates.count).forEach { index in
+            (0..<Metric.maximumDivideValue.rawValue).forEach { count in
+                if isEven(number: index) && isEven(number: count) {
+                    self.coordinates[index].append(
+                        (x: viewSize * CGFloat(count), y: viewSize * CGFloat(index)
+                        )
+                    )
+                } else if !isEven(number: index) && !isEven(number: count) {
+                    self.coordinates[index].append(
+                        (x: viewSize * CGFloat(count), y: viewSize * CGFloat(index))
+                    )
+                }
+            }
+        }
+    }
+    
+    public func addImageViews(width: CGFloat, height: CGFloat) {
+        let _ = width / CGFloat(Metric.minimumDivideValue.rawValue)
+        let maximumSize = width / CGFloat(Metric.maximumDivideValue.rawValue)
+    
+        coordinates.forEach { row in
+            row.forEach { (x, y) in
+                let imageView = UIImageView(image: self.mainImage)
+                imageView.translatesAutoresizingMaskIntoConstraints = false
+                imageView.layer.opacity = 0.5
+                self.addSubview(imageView)
+                self.imageViews.append(imageView)
+                NSLayoutConstraint.activate([
+                    imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: x),
+                    imageView.topAnchor.constraint(equalTo: self.topAnchor, constant: y),
+                    imageView.widthAnchor.constraint(equalToConstant: maximumSize),
+                    imageView.heightAnchor.constraint(equalToConstant: maximumSize),
+                ])
+            }
+        }
+    }
+    
+    public func createCoordinatesArray(count: Int) {
+        (0..<count).forEach { _ in
+            self.coordinates.append([])
+        }
+    }
+    
+    public func isEven(number: Int) -> Bool {
+        return number % 2 == 0
+    }
+    
+}
+


### PR DESCRIPTION
사용자가 등록한이미지를 체스모양의 뷰로 보여주는 `ABCheckboardView`를 구현하였습니다.
- 기본으로 등록되어있는 이미지를 사용하기 위해 UIImage(systemName:)메서드를 사용합니다. 해당 메서드는 iOS13이상부터 사용할 수 있기에 허용 버전을 iOS13 이상의 버전으로 하였습니다.
- 이미지는 위에서부터 아래로 커졌다 작아졌다 하는 애니메이션을 반복합니다.
    - 이미지가 가장 작을 때의 사이즈는 전체 뷰 너비의 1/8입니다.
    - 이미지가 가장 클때의 사이즈는 전체 뷰 너비의 1/6입니다. 